### PR TITLE
fix: add required dependency latest changes

### DIFF
--- a/config/.config/nvim/lua/custom/plugins.lua
+++ b/config/.config/nvim/lua/custom/plugins.lua
@@ -78,6 +78,7 @@ local plugins = {
     'Exafunction/codeium.vim',
     event = 'BufEnter'
   },
+  { "nvim-neotest/nvim-nio" },
   {
     "ellisonleao/glow.nvim",
     config = function ()


### PR DESCRIPTION
i needed to update the plugins since codeium started to fail. new versions require [nvim-nio](https://github.com/nvim-neotest/nvim-nio)